### PR TITLE
Add optional parameters to go client using map[string]interface{} (#4…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 *.iml
 out/
 *.ipr

--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -34,10 +34,12 @@ func New{{classname}}WithBasePath(basePath string) *{{classname}} {
  * {{summary}}{{#notes}}
  * {{notes}}{{/notes}}
  *
-{{#allParams}} * @param {{paramName}} {{description}}
-{{/allParams}} * @return {{#returnType}}{{^isListContainer}}*{{/isListContainer}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
+{{#allParams}}{{#required}} * @param {{paramName}} {{description}}
+{{/required}}{{/allParams}}{{#hasOptionalParams}} * @param optional (nil or map[string]interface{}) with one or more of:
+{{#allParams}}{{^required}} *     @param "{{paramName}}" ({{dataType}}) {{description}}
+{{/required}}{{/allParams}}{{/hasOptionalParams}} * @return {{#returnType}}{{^isListContainer}}*{{/isListContainer}}{{{returnType}}}{{/returnType}}
  */
-func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) ({{#returnType}}{{^isListContainer}}*{{/isListContainer}}{{{returnType}}}, {{/returnType}}*APIResponse, error) {
+func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals map[string]interface{}{{/hasOptionalParams}}) ({{#returnType}}{{^isListContainer}}*{{/isListContainer}}{{{returnType}}}, {{/returnType}}*APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("{{httpMethod}}")
 	// create path and map variables
@@ -81,19 +83,14 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 	}
 	{{#hasQueryParams}}
 	{{#queryParams}}
-	{{#isListContainer}}
-	var collectionFormat = "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"
-	if collectionFormat == "multi" {
-		for _, value := range {{paramName}} {
-			localVarQueryParams.Add("{{baseName}}", value)
-		}
-	} else {
-		localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, collectionFormat))
+	{{#required}}
+	localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	{{/required}}
+	{{^required}}
+	if localVarTempParam, localVarOk := localVarOptionals["{{paramName}}"].({{dataType}}); localVarOptionals != nil && localVarOk {
+		localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString(localVarTempParam, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	}
-	{{/isListContainer}}
-	{{^isListContainer}}
-		localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, ""))
-	{{/isListContainer}}
+	{{/required}}
 	{{/queryParams}}
 	{{/hasQueryParams}}
 
@@ -119,25 +116,52 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 	}
 {{#hasHeaderParams}}
 {{#headerParams}}
-	// header params "{{baseName}}"
-	localVarHeaderParams["{{baseName}}"] = a.Configuration.APIClient.ParameterToString({{paramName}}, "")
+	{{#required}}
+	localVarHeaderParams["{{baseName}}"] = a.Configuration.APIClient.ParameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	{{/required}}
+	{{^required}}
+	if localVarTempParam, localVarOk := localVarOptionals["{{paramName}}"].({{dataType}}); localVarOptionals != nil && localVarOk {
+		localVarHeaderParams["{{baseName}}"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	}
+	{{/required}}
 {{/headerParams}}
 {{/hasHeaderParams}}
 {{#hasFormParams}}
 {{#formParams}}
 {{#isFile}}
-	fbs, _ := ioutil.ReadAll(file)
-	localVarFileBytes = fbs
-	localVarFileName = file.Name()
+{{^required}}
+	var file ({{dataType}})
+	if localVarTempParam, localVarOk := localVarOptionals["{{paramName}}"].({{dataType}}); localVarOptionals != nil && localVarOk {
+		file = localVarTempParam
+	}
+{{/required}}
+	if file != nil {
+		fbs, _ := ioutil.ReadAll(file)
+		localVarFileBytes = fbs
+		localVarFileName = file.Name()
+	}
 {{/isFile}}
 {{^isFile}}
-	localVarFormParams["{{paramName}}"] = a.Configuration.APIClient.ParameterToString({{paramName}}, "")
+{{#required}}
+	localVarFormParams["{{baseName}}"] = a.Configuration.APIClient.ParameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+{{/required}}
+{{^required}}
+	if localVarTempParam, localVarOk := localVarOptionals["{{paramName}}"].({{dataType}}); localVarOptionals != nil && localVarOk {
+		localVarFormParams["{{baseName}}"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	}
+{{/required}}
 {{/isFile}}
 {{/formParams}}
 {{/hasFormParams}}
 {{#hasBodyParam}}
 {{#bodyParams}}	// body params
-	localVarPostBody = &{{paramName}}
+{{#required}}
+	localVarPostBody = &{{paramName}}{{/required}}
+{{^required}}
+	if localVarTempParam, localVarOk := localVarOptionals["{{paramName}}"].({{dataType}}); localVarOptionals != nil && localVarOk {
+		localVarPostBody = &localVarTempParam
+	}
+{{/required}}
 {{/bodyParams}}
 {{/hasBodyParam}}
 {{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/go/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api_doc.mustache
@@ -24,10 +24,14 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
 {{#allParams}} **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{^required}}[optional] {{/required}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/allParams}}
+{{#hasOptionalParams}}
+
+Note: Optional parameters are passed through a map[string]interface{}
+{{/hasOptionalParams}}
 
 ### Return type
 
-{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}void (empty response body){{/returnType}}
+{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}(empty response body){{/returnType}}
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -24,6 +24,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestClientModel**](docs/FakeApi.md#testclientmodel) | **Patch** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**TestEndpointParameters**](docs/FakeApi.md#testendpointparameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**TestEnumParameters**](docs/FakeApi.md#testenumparameters) | **Get** /fake | To test enum parameters
+*Fake_classname_tags123Api* | [**TestClassname**](docs/Fake_classname_tags123Api.md#testclassname) | **Patch** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **Post** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **Delete** /pet/{petId} | Deletes a pet
 *PetApi* | [**FindPetsByStatus**](docs/PetApi.md#findpetsbystatus) | **Get** /pet/findByStatus | Finds Pets by status

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -37,7 +37,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **TestEndpointParameters**
-> TestEndpointParameters($number, $double, $patternWithoutDelimiter, $byte_, $integer, $int32_, $int64_, $float, $string_, $binary, $date, $dateTime, $password)
+> TestEndpointParameters($number, $double, $patternWithoutDelimiter, $byte_, $integer, $int32_, $int64_, $float, $string_, $binary, $date, $dateTime, $password, $callback)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -61,10 +61,13 @@ Name | Type | Description  | Notes
  **date** | **time.Time**| None | [optional] 
  **dateTime** | **time.Time**| None | [optional] 
  **password** | **string**| None | [optional] 
+ **callback** | **string**| None | [optional] 
+
+Note: Optional parameters are passed through a map[string]interface{}
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -96,9 +99,11 @@ Name | Type | Description  | Notes
  **enumQueryInteger** | **float32**| Query parameter enum test (double) | [optional] 
  **enumQueryDouble** | **float64**| Query parameter enum test (double) | [optional] 
 
+Note: Optional parameters are passed through a map[string]interface{}
+
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -106,8 +111,8 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
- - **Accept**: application/json
+ - **Content-Type**: */*
+ - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -30,7 +30,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -58,9 +58,11 @@ Name | Type | Description  | Notes
  **petId** | **int64**| Pet id to delete | 
  **apiKey** | **string**|  | [optional] 
 
+Note: Optional parameters are passed through a map[string]interface{}
+
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -176,7 +178,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -205,9 +207,11 @@ Name | Type | Description  | Notes
  **name** | **string**| Updated name of the pet | [optional] 
  **status** | **string**| Updated status of the pet | [optional] 
 
+Note: Optional parameters are passed through a map[string]interface{}
+
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -235,6 +239,8 @@ Name | Type | Description  | Notes
  **petId** | **int64**| ID of pet to update | 
  **additionalMetadata** | **string**| Additional data to pass to server | [optional] 
  **file** | ***os.File**| file to upload | [optional] 
+
+Note: Optional parameters are passed through a map[string]interface{}
 
 ### Return type
 

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -26,7 +26,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -30,7 +30,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -59,7 +59,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -88,7 +88,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -117,7 +117,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -202,7 +202,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 
@@ -232,7 +232,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-void (empty response body)
+(empty response body)
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/fake_api.go
+++ b/samples/client/petstore/go/go-petstore/fake_api.go
@@ -118,18 +118,20 @@ func (a FakeApi) TestClientModel(body Client) (*Client, *APIResponse, error) {
  * @param double None
  * @param patternWithoutDelimiter None
  * @param byte_ None
- * @param integer None
- * @param int32_ None
- * @param int64_ None
- * @param float None
- * @param string_ None
- * @param binary None
- * @param date None
- * @param dateTime None
- * @param password None
- * @return void
+ * @param optional (nil or map[string]interface{}) with one or more of:
+ *     @param "integer" (int32) None
+ *     @param "int32_" (int32) None
+ *     @param "int64_" (int64) None
+ *     @param "float" (float32) None
+ *     @param "string_" (string) None
+ *     @param "binary" (string) None
+ *     @param "date" (time.Time) None
+ *     @param "dateTime" (time.Time) None
+ *     @param "password" (string) None
+ *     @param "callback" (string) None
+ * @return 
  */
-func (a FakeApi) TestEndpointParameters(number float32, double float64, patternWithoutDelimiter string, byte_ string, integer int32, int32_ int32, int64_ int64, float float32, string_ string, binary string, date time.Time, dateTime time.Time, password string) (*APIResponse, error) {
+func (a FakeApi) TestEndpointParameters(number float32, double float64, patternWithoutDelimiter string, byte_ string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -170,19 +172,40 @@ func (a FakeApi) TestEndpointParameters(number float32, double float64, patternW
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	localVarFormParams["integer"] = a.Configuration.APIClient.ParameterToString(integer, "")
-	localVarFormParams["int32_"] = a.Configuration.APIClient.ParameterToString(int32_, "")
-	localVarFormParams["int64_"] = a.Configuration.APIClient.ParameterToString(int64_, "")
+	if localVarTempParam, localVarOk := localVarOptionals["integer"].(int32); localVarOptionals != nil && localVarOk {
+		localVarFormParams["integer"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["int32_"].(int32); localVarOptionals != nil && localVarOk {
+		localVarFormParams["int32"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["int64_"].(int64); localVarOptionals != nil && localVarOk {
+		localVarFormParams["int64"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarFormParams["number"] = a.Configuration.APIClient.ParameterToString(number, "")
-	localVarFormParams["float"] = a.Configuration.APIClient.ParameterToString(float, "")
+	if localVarTempParam, localVarOk := localVarOptionals["float"].(float32); localVarOptionals != nil && localVarOk {
+		localVarFormParams["float"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarFormParams["double"] = a.Configuration.APIClient.ParameterToString(double, "")
-	localVarFormParams["string_"] = a.Configuration.APIClient.ParameterToString(string_, "")
-	localVarFormParams["patternWithoutDelimiter"] = a.Configuration.APIClient.ParameterToString(patternWithoutDelimiter, "")
-	localVarFormParams["byte_"] = a.Configuration.APIClient.ParameterToString(byte_, "")
-	localVarFormParams["binary"] = a.Configuration.APIClient.ParameterToString(binary, "")
-	localVarFormParams["date"] = a.Configuration.APIClient.ParameterToString(date, "")
-	localVarFormParams["dateTime"] = a.Configuration.APIClient.ParameterToString(dateTime, "")
-	localVarFormParams["password"] = a.Configuration.APIClient.ParameterToString(password, "")
+	if localVarTempParam, localVarOk := localVarOptionals["string_"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["string"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	localVarFormParams["pattern_without_delimiter"] = a.Configuration.APIClient.ParameterToString(patternWithoutDelimiter, "")
+	localVarFormParams["byte"] = a.Configuration.APIClient.ParameterToString(byte_, "")
+	if localVarTempParam, localVarOk := localVarOptionals["binary"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["binary"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["date"].(time.Time); localVarOptionals != nil && localVarOk {
+		localVarFormParams["date"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["dateTime"].(time.Time); localVarOptionals != nil && localVarOk {
+		localVarFormParams["dateTime"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["password"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["password"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["callback"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["callback"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 
 	var localVarURL, _ = url.Parse(localVarPath)
@@ -202,17 +225,18 @@ func (a FakeApi) TestEndpointParameters(number float32, double float64, patternW
 /**
  * To test enum parameters
  *
- * @param enumFormStringArray Form parameter enum test (string array)
- * @param enumFormString Form parameter enum test (string)
- * @param enumHeaderStringArray Header parameter enum test (string array)
- * @param enumHeaderString Header parameter enum test (string)
- * @param enumQueryStringArray Query parameter enum test (string array)
- * @param enumQueryString Query parameter enum test (string)
- * @param enumQueryInteger Query parameter enum test (double)
- * @param enumQueryDouble Query parameter enum test (double)
- * @return void
+ * @param optional (nil or map[string]interface{}) with one or more of:
+ *     @param "enumFormStringArray" ([]string) Form parameter enum test (string array)
+ *     @param "enumFormString" (string) Form parameter enum test (string)
+ *     @param "enumHeaderStringArray" ([]string) Header parameter enum test (string array)
+ *     @param "enumHeaderString" (string) Header parameter enum test (string)
+ *     @param "enumQueryStringArray" ([]string) Query parameter enum test (string array)
+ *     @param "enumQueryString" (string) Query parameter enum test (string)
+ *     @param "enumQueryInteger" (float32) Query parameter enum test (double)
+ *     @param "enumQueryDouble" (float64) Query parameter enum test (double)
+ * @return 
  */
-func (a FakeApi) TestEnumParameters(enumFormStringArray []string, enumFormString string, enumHeaderStringArray []string, enumHeaderString string, enumQueryStringArray []string, enumQueryString string, enumQueryInteger float32, enumQueryDouble float64) (*APIResponse, error) {
+func (a FakeApi) TestEnumParameters(localVarOptionals map[string]interface{}) (*APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -228,19 +252,18 @@ func (a FakeApi) TestEnumParameters(enumFormStringArray []string, enumFormString
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
-	var collectionFormat = "csv"
-	if collectionFormat == "multi" {
-		for _, value := range enumQueryStringArray {
-			localVarQueryParams.Add("enum_query_string_array", value)
-		}
-	} else {
-		localVarQueryParams.Add("enum_query_string_array", a.Configuration.APIClient.ParameterToString(enumQueryStringArray, collectionFormat))
+	if localVarTempParam, localVarOk := localVarOptionals["enumQueryStringArray"].([]string); localVarOptionals != nil && localVarOk {
+		localVarQueryParams.Add("enum_query_string_array", a.Configuration.APIClient.ParameterToString(localVarTempParam, "csv"))
 	}
-		localVarQueryParams.Add("enum_query_string", a.Configuration.APIClient.ParameterToString(enumQueryString, ""))
-		localVarQueryParams.Add("enum_query_integer", a.Configuration.APIClient.ParameterToString(enumQueryInteger, ""))
+	if localVarTempParam, localVarOk := localVarOptionals["enumQueryString"].(string); localVarOptionals != nil && localVarOk {
+		localVarQueryParams.Add("enum_query_string", a.Configuration.APIClient.ParameterToString(localVarTempParam, ""))
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["enumQueryInteger"].(float32); localVarOptionals != nil && localVarOk {
+		localVarQueryParams.Add("enum_query_integer", a.Configuration.APIClient.ParameterToString(localVarTempParam, ""))
+	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{ "*/*",  }
 
 	// set Content-Type header
 	localVarHttpContentType := a.Configuration.APIClient.SelectHeaderContentType(localVarHttpContentTypes)
@@ -249,7 +272,7 @@ func (a FakeApi) TestEnumParameters(enumFormStringArray []string, enumFormString
 	}
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
-		"application/json",
+		"*/*",
 		}
 
 	// set Accept header
@@ -257,13 +280,21 @@ func (a FakeApi) TestEnumParameters(enumFormStringArray []string, enumFormString
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	// header params "enum_header_string_array"
-	localVarHeaderParams["enum_header_string_array"] = a.Configuration.APIClient.ParameterToString(enumHeaderStringArray, "")
-	// header params "enum_header_string"
-	localVarHeaderParams["enum_header_string"] = a.Configuration.APIClient.ParameterToString(enumHeaderString, "")
-	localVarFormParams["enumFormStringArray"] = a.Configuration.APIClient.ParameterToString(enumFormStringArray, "")
-	localVarFormParams["enumFormString"] = a.Configuration.APIClient.ParameterToString(enumFormString, "")
-	localVarFormParams["enumQueryDouble"] = a.Configuration.APIClient.ParameterToString(enumQueryDouble, "")
+	if localVarTempParam, localVarOk := localVarOptionals["enumHeaderStringArray"].([]string); localVarOptionals != nil && localVarOk {
+		localVarHeaderParams["enum_header_string_array"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "csv")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["enumHeaderString"].(string); localVarOptionals != nil && localVarOk {
+		localVarHeaderParams["enum_header_string"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["enumFormStringArray"].([]string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["enum_form_string_array"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "csv")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["enumFormString"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["enum_form_string"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["enumQueryDouble"].(float64); localVarOptionals != nil && localVarOk {
+		localVarFormParams["enum_query_double"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 
 	var localVarURL, _ = url.Parse(localVarPath)

--- a/samples/client/petstore/go/go-petstore/pet_api.go
+++ b/samples/client/petstore/go/go-petstore/pet_api.go
@@ -56,7 +56,7 @@ func NewPetApiWithBasePath(basePath string) *PetApi {
  * 
  *
  * @param body Pet object that needs to be added to the store
- * @return void
+ * @return 
  */
 func (a PetApi) AddPet(body Pet) (*APIResponse, error) {
 
@@ -122,10 +122,11 @@ func (a PetApi) AddPet(body Pet) (*APIResponse, error) {
  * 
  *
  * @param petId Pet id to delete
- * @param apiKey 
- * @return void
+ * @param optional (nil or map[string]interface{}) with one or more of:
+ *     @param "apiKey" (string) 
+ * @return 
  */
-func (a PetApi) DeletePet(petId int64, apiKey string) (*APIResponse, error) {
+func (a PetApi) DeletePet(petId int64, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Delete")
 	// create path and map variables
@@ -167,8 +168,9 @@ func (a PetApi) DeletePet(petId int64, apiKey string) (*APIResponse, error) {
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	// header params "api_key"
-	localVarHeaderParams["api_key"] = a.Configuration.APIClient.ParameterToString(apiKey, "")
+	if localVarTempParam, localVarOk := localVarOptionals["apiKey"].(string); localVarOptionals != nil && localVarOk {
+		localVarHeaderParams["api_key"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 
 	var localVarURL, _ = url.Parse(localVarPath)
@@ -213,14 +215,7 @@ func (a PetApi) FindPetsByStatus(status []string) ([]Pet, *APIResponse, error) {
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
-	var collectionFormat = "csv"
-	if collectionFormat == "multi" {
-		for _, value := range status {
-			localVarQueryParams.Add("status", value)
-		}
-	} else {
-		localVarQueryParams.Add("status", a.Configuration.APIClient.ParameterToString(status, collectionFormat))
-	}
+	localVarQueryParams.Add("status", a.Configuration.APIClient.ParameterToString(status, "csv"))
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{  }
@@ -287,14 +282,7 @@ func (a PetApi) FindPetsByTags(tags []string) ([]Pet, *APIResponse, error) {
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
-	var collectionFormat = "csv"
-	if collectionFormat == "multi" {
-		for _, value := range tags {
-			localVarQueryParams.Add("tags", value)
-		}
-	} else {
-		localVarQueryParams.Add("tags", a.Configuration.APIClient.ParameterToString(tags, collectionFormat))
-	}
+	localVarQueryParams.Add("tags", a.Configuration.APIClient.ParameterToString(tags, "csv"))
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{  }
@@ -403,7 +391,7 @@ func (a PetApi) GetPetById(petId int64) (*Pet, *APIResponse, error) {
  * 
  *
  * @param body Pet object that needs to be added to the store
- * @return void
+ * @return 
  */
 func (a PetApi) UpdatePet(body Pet) (*APIResponse, error) {
 
@@ -469,11 +457,12 @@ func (a PetApi) UpdatePet(body Pet) (*APIResponse, error) {
  * 
  *
  * @param petId ID of pet that needs to be updated
- * @param name Updated name of the pet
- * @param status Updated status of the pet
- * @return void
+ * @param optional (nil or map[string]interface{}) with one or more of:
+ *     @param "name" (string) Updated name of the pet
+ *     @param "status" (string) Updated status of the pet
+ * @return 
  */
-func (a PetApi) UpdatePetWithForm(petId int64, name string, status string) (*APIResponse, error) {
+func (a PetApi) UpdatePetWithForm(petId int64, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -515,8 +504,12 @@ func (a PetApi) UpdatePetWithForm(petId int64, name string, status string) (*API
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	localVarFormParams["name"] = a.Configuration.APIClient.ParameterToString(name, "")
-	localVarFormParams["status"] = a.Configuration.APIClient.ParameterToString(status, "")
+	if localVarTempParam, localVarOk := localVarOptionals["name"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["name"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["status"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["status"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 
 	var localVarURL, _ = url.Parse(localVarPath)
@@ -538,11 +531,12 @@ func (a PetApi) UpdatePetWithForm(petId int64, name string, status string) (*API
  * 
  *
  * @param petId ID of pet to update
- * @param additionalMetadata Additional data to pass to server
- * @param file file to upload
+ * @param optional (nil or map[string]interface{}) with one or more of:
+ *     @param "additionalMetadata" (string) Additional data to pass to server
+ *     @param "file" (*os.File) file to upload
  * @return *ModelApiResponse
  */
-func (a PetApi) UploadFile(petId int64, additionalMetadata string, file *os.File) (*ModelApiResponse, *APIResponse, error) {
+func (a PetApi) UploadFile(petId int64, localVarOptionals map[string]interface{}) (*ModelApiResponse, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -583,10 +577,18 @@ func (a PetApi) UploadFile(petId int64, additionalMetadata string, file *os.File
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	localVarFormParams["additionalMetadata"] = a.Configuration.APIClient.ParameterToString(additionalMetadata, "")
-	fbs, _ := ioutil.ReadAll(file)
-	localVarFileBytes = fbs
-	localVarFileName = file.Name()
+	if localVarTempParam, localVarOk := localVarOptionals["additionalMetadata"].(string); localVarOptionals != nil && localVarOk {
+		localVarFormParams["additionalMetadata"] = a.Configuration.APIClient.ParameterToString(localVarTempParam, "")
+	}
+	var file (*os.File)
+	if localVarTempParam, localVarOk := localVarOptionals["file"].(*os.File); localVarOptionals != nil && localVarOk {
+		file = localVarTempParam
+	}
+	if file != nil {
+		fbs, _ := ioutil.ReadAll(file)
+		localVarFileBytes = fbs
+		localVarFileName = file.Name()
+	}
 	var successPayload = new(ModelApiResponse)
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 

--- a/samples/client/petstore/go/go-petstore/store_api.go
+++ b/samples/client/petstore/go/go-petstore/store_api.go
@@ -54,7 +54,7 @@ func NewStoreApiWithBasePath(basePath string) *StoreApi {
  * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
  *
  * @param orderId ID of the order that needs to be deleted
- * @return void
+ * @return 
  */
 func (a StoreApi) DeleteOrder(orderId string) (*APIResponse, error) {
 

--- a/samples/client/petstore/go/go-petstore/user_api.go
+++ b/samples/client/petstore/go/go-petstore/user_api.go
@@ -54,7 +54,7 @@ func NewUserApiWithBasePath(basePath string) *UserApi {
  * This can only be done by the logged in user.
  *
  * @param body Created user object
- * @return void
+ * @return 
  */
 func (a UserApi) CreateUser(body User) (*APIResponse, error) {
 
@@ -115,7 +115,7 @@ func (a UserApi) CreateUser(body User) (*APIResponse, error) {
  * 
  *
  * @param body List of user object
- * @return void
+ * @return 
  */
 func (a UserApi) CreateUsersWithArrayInput(body []User) (*APIResponse, error) {
 
@@ -176,7 +176,7 @@ func (a UserApi) CreateUsersWithArrayInput(body []User) (*APIResponse, error) {
  * 
  *
  * @param body List of user object
- * @return void
+ * @return 
  */
 func (a UserApi) CreateUsersWithListInput(body []User) (*APIResponse, error) {
 
@@ -237,7 +237,7 @@ func (a UserApi) CreateUsersWithListInput(body []User) (*APIResponse, error) {
  * This can only be done by the logged in user.
  *
  * @param username The name that needs to be deleted
- * @return void
+ * @return 
  */
 func (a UserApi) DeleteUser(username string) (*APIResponse, error) {
 
@@ -378,8 +378,8 @@ func (a UserApi) LoginUser(username string, password string) (*string, *APIRespo
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
-		localVarQueryParams.Add("username", a.Configuration.APIClient.ParameterToString(username, ""))
-		localVarQueryParams.Add("password", a.Configuration.APIClient.ParameterToString(password, ""))
+	localVarQueryParams.Add("username", a.Configuration.APIClient.ParameterToString(username, ""))
+	localVarQueryParams.Add("password", a.Configuration.APIClient.ParameterToString(password, ""))
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{  }
@@ -422,7 +422,7 @@ func (a UserApi) LoginUser(username string, password string) (*string, *APIRespo
  * Logs out current logged in user session
  * 
  *
- * @return void
+ * @return 
  */
 func (a UserApi) LogoutUser() (*APIResponse, error) {
 
@@ -482,7 +482,7 @@ func (a UserApi) LogoutUser() (*APIResponse, error) {
  *
  * @param username name that need to be deleted
  * @param body Updated user object
- * @return void
+ * @return 
  */
 func (a UserApi) UpdateUser(username string, body User) (*APIResponse, error) {
 

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
-	sw "./go-petstore"
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"os"
 	"testing"
+
+	"time"
+
+	sw "./go-petstore"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddPet(t *testing.T) {
@@ -38,23 +42,8 @@ func TestFindPetsByStatusWithMissingParam(t *testing.T) {
 }
 
 func TestGetPetById(t *testing.T) {
-	assert := assert.New(t)
-
 	s := sw.NewPetApi()
-	resp, apiResponse, err := s.GetPetById(12830)
-	if err != nil {
-		t.Errorf("Error while getting pet by id")
-		t.Log(err)
-	} else {
-		assert.Equal(resp.Id, int64(12830), "Pet id should be equal")
-		assert.Equal(resp.Name, "gopher", "Pet name should be gopher")
-		assert.Equal(resp.Status, "pending", "Pet status should be pending")
-
-		//t.Log(resp)
-	}
-	if apiResponse.Response.StatusCode != 200 {
-		t.Log(apiResponse.Response)
-	}
+	isPetCorrect(t, s, 12830, "gopher", "pending")
 }
 
 func TestGetPetByIdWithInvalidID(t *testing.T) {
@@ -74,7 +63,10 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 
 func TestUpdatePetWithForm(t *testing.T) {
 	s := sw.NewPetApi()
-	apiResponse, err := s.UpdatePetWithForm(12830, "golang", "available")
+	apiResponse, err := s.UpdatePetWithForm(12830, map[string]interface{}{
+		"name":   "golang",
+		"status": "available",
+	})
 
 	if err != nil {
 		t.Errorf("Error while updating pet by id")
@@ -113,7 +105,10 @@ func TestUploadFile(t *testing.T) {
 	s := sw.NewPetApi()
 	file, _ := os.Open("../python/testfiles/foo.png")
 
-	_, apiResponse, err := s.UploadFile(12830, "golang", file)
+	_, apiResponse, err := s.UploadFile(12830, map[string]interface{}{
+		"additionalMetadata": "golang",
+		"file":               file,
+	})
 
 	if err != nil {
 		t.Errorf("Error while uploading file")
@@ -127,11 +122,79 @@ func TestUploadFile(t *testing.T) {
 
 func TestDeletePet(t *testing.T) {
 	s := sw.NewPetApi()
-	apiResponse, err := s.DeletePet(12830, "")
+	deletePet(t, s, 12830)
+}
+
+func TestConcurrency(t *testing.T) {
+	s := sw.NewPetApi()
+	errc := make(chan error)
+
+	newPets := []sw.Pet{sw.Pet{Id: 12345, Name: "gopherFred", PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending"},
+		sw.Pet{Id: 12346, Name: "gopherDan", PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "active"},
+		sw.Pet{Id: 12347, Name: "gopherRick", PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "mia"},
+		sw.Pet{Id: 12348, Name: "gopherJohn", PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "dead"}}
+
+	// Add the pets at the same time.
+	for _, pet := range newPets {
+		go func(newPet sw.Pet) {
+			apiResponse, err := s.AddPet(newPet)
+			if apiResponse.Response.StatusCode != 200 {
+				t.Log(apiResponse.Response)
+			}
+			errc <- err
+		}(pet)
+	}
+
+	// Wait for the go routines to finish
+	for i := 0; i < len(newPets); i++ {
+		err := <-errc
+		if err != nil {
+			t.Errorf("Error while adding pet")
+			t.Log(err)
+		}
+	}
+
+	// Sleep for just a moment to let the backend catch up
+	// Getting random 404 errors from the backend
+	time.Sleep(time.Second)
+
+	// Verify they are correct.
+	isPetCorrect(t, s, 12345, "gopherFred", "pending")
+	isPetCorrect(t, s, 12346, "gopherDan", "active")
+	isPetCorrect(t, s, 12347, "gopherRick", "mia")
+	isPetCorrect(t, s, 12348, "gopherJohn", "dead")
+
+	// Get rid of them.
+	deletePet(t, s, 12345)
+	deletePet(t, s, 12346)
+	deletePet(t, s, 12347)
+	deletePet(t, s, 12348)
+}
+
+func deletePet(t *testing.T, s *sw.PetApi, id int64) {
+	apiResponse, err := s.DeletePet(id, nil)
 
 	if err != nil {
 		t.Errorf("Error while deleting pet by id")
 		t.Log(err)
+	}
+	if apiResponse.Response.StatusCode != 200 {
+		t.Log(apiResponse.Response)
+	}
+}
+
+func isPetCorrect(t *testing.T, s *sw.PetApi, id int64, name string, status string) {
+	assert := assert.New(t)
+	resp, apiResponse, err := s.GetPetById(id)
+	if err != nil {
+		t.Errorf("Error while getting pet by id")
+		t.Log(err)
+	} else {
+		assert.Equal(resp.Id, int64(id), "Pet id should be equal")
+		assert.Equal(resp.Name, name, fmt.Sprintf("Pet name should be %s", name))
+		assert.Equal(resp.Status, status, fmt.Sprintf("Pet status should be %s", status))
+
+		//t.Log(resp)
 	}
 	if apiResponse.Response.StatusCode != 200 {
 		t.Log(apiResponse.Response)


### PR DESCRIPTION
…415)

* Add VSCode to the list of ignores.

* Move optional parameters into a map[string]interface{}
Refactor tests to new API and add concurrency test.

* Add optional check to postBody.
The pet-store does not create this scenario.

### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

